### PR TITLE
Revert "DIRTY HACK TO MAKE ORDERS WORK ON v3"

### DIFF
--- a/bigcommerce/connection.py
+++ b/bigcommerce/connection.py
@@ -55,10 +55,7 @@ class Connection(object):
 
         # Support v3
         if self.api_path and 'v3' in self.api_path:
-            if url is 'orders':
-                self.api_path = self.api_path.replace('v3', 'v2')
-            else:
-                url = 'catalog/{}'.format(url)
+            url = 'catalog/{}'.format(url)
 
         # make full path if not given
         if url and url[:4] != "http":


### PR DESCRIPTION
This reverts commit c71d4a68

Looks like v3 and orders stops products being returned on the orders call, reverting this.